### PR TITLE
HOTFIX: allow including spaces in DisplayName or Description

### DIFF
--- a/Extensions/WindowsServiceReleaseTasks/Src/Tasks/InstallTopshelfService/InstallTopshelfService.ps1
+++ b/Extensions/WindowsServiceReleaseTasks/Src/Tasks/InstallTopshelfService/InstallTopshelfService.ps1
@@ -60,11 +60,11 @@ Try
 	}
 	if (-Not [string]::IsNullOrWhiteSpace($displayName))
 	{
-		$additionalSharedArguments += " -displayname:$displayName"
+		$additionalSharedArguments += " -displayname ""$displayName"""
 	}
 	if (-Not [string]::IsNullOrWhiteSpace($description))
 	{
-		$additionalSharedArguments += " -description:$description"
+		$additionalSharedArguments += " -description ""$description"""
 	}
 	
 	$additonalInstallArguments = ""


### PR DESCRIPTION
When adding spaces in DisplayName or Service description, there is an error and the service is not created.
By using the syntax -displayname "Display name of the service" it works.
Fixes issue #13 