### PR TITLE
feat: Allow Start-Service and Stop-Service to support wildcards

### DIFF
--- a/Extensions/WindowsServiceReleaseTasks/Src/Tasks/StartWindowsService/task.json
+++ b/Extensions/WindowsServiceReleaseTasks/Src/Tasks/StartWindowsService/task.json
@@ -15,7 +15,7 @@
         "Minor": "{{tokens.Minor}}",
         "Patch": "{{tokens.Patch}}"
     },
-    "minimumAgentVersion": "1.95.0",	
+    "minimumAgentVersion": "1.95.0",
     "inputs": [
         {
             "name": "ServiceNames",
@@ -23,7 +23,7 @@
             "label": "Service Names",
             "defaultValue": "",
             "required": true,
-            "helpMarkDown": "The name of the windows service to start. Comma separate to stop multiple." 
+            "helpMarkDown": "The name of the windows service to start. Comma separate to stop multiple. Supports wildcards (*)."
         },
         {
             "name": "EnvironmentName",

--- a/Extensions/WindowsServiceReleaseTasks/Src/Tasks/StopWindowsService/task.json
+++ b/Extensions/WindowsServiceReleaseTasks/Src/Tasks/StopWindowsService/task.json
@@ -15,7 +15,7 @@
         "Minor": "{{tokens.Minor}}",
         "Patch": "{{tokens.Patch}}"
     },
-    "minimumAgentVersion": "1.95.0",	
+    "minimumAgentVersion": "1.95.0",
     "inputs": [
         {
             "name": "ServiceNames",
@@ -23,7 +23,7 @@
             "label": "Service Names",
             "defaultValue": "",
             "required": true,
-            "helpMarkDown": "The name of the windows service to stop. Comma separate to stop multiple." 
+            "helpMarkDown": "The name of the windows service to stop. Comma separate to stop multiple. Supports wildcards (*)."
         },
         {
             "name": "EnvironmentName",


### PR DESCRIPTION
Allow Start-Service and Stop-Service to support wildcards in the service name.

Addresses Issue #19 