### PR TITLE
Add support for usernames with spaces

### DIFF
--- a/Extensions/WindowsServiceReleaseTasks/Src/Tasks/InstallTopshelfService/InstallTopshelfService.ps1
+++ b/Extensions/WindowsServiceReleaseTasks/Src/Tasks/InstallTopshelfService/InstallTopshelfService.ps1
@@ -35,7 +35,7 @@ Try {
         
         Write-Host ("##vso[task.setvariable variable=E34A69771F47424D9217F3A4D6BCDC95;issecret=true;]$servicePassword")  # Make sure the password doesn't show up in the log.
         
-        $additionalSharedArguments += " -username:$serviceUsername"
+        $additionalSharedArguments += " -username ""$serviceUsername"""
         if (-Not [string]::IsNullOrWhiteSpace($servicePassword)) {
             $additionalSharedArguments += " -password:""$servicePassword"""
         }


### PR DESCRIPTION
I've got a service account with spaces in it.  When installing a service using the colon syntax on the username argument and when the provided value has a space in it, Topshelf throws errors.  However, this is not the case when using the space syntax for the username argument.