### PR TITLE
To fix the issue #50 about installing a service with custom credentials 

### DIFF
--- a/Extensions/WindowsServiceReleaseTasks/Src/Tasks/InstallTopshelfService/InstallTopshelfService.ps1
+++ b/Extensions/WindowsServiceReleaseTasks/Src/Tasks/InstallTopshelfService/InstallTopshelfService.ps1
@@ -35,7 +35,7 @@ Try {
         
         Write-Host ("##vso[task.setvariable variable=E34A69771F47424D9217F3A4D6BCDC95;issecret=true;]$servicePassword")  # Make sure the password doesn't show up in the log.
         
-        $additionalSharedArguments += " -username ""$serviceUsername"" -password"
+        $additionalSharedArguments += " -username:""$serviceUsername"" -password"
         if (-Not [string]::IsNullOrWhiteSpace($servicePassword)) {
             $additionalSharedArguments += ":""$servicePassword"""
         }


### PR DESCRIPTION
To fix the issue  #50 raised on May 28 by @luke-barnett  

The issue appears on task version 8 as the script generated by the task looks like the following:
MyTopShelfService.exe" install  -username "MyUserName" -password:"***" 

While the above works perfectly fine in windows command prompt and in older task versions (probably due to a different version in PowerShell there), it fails if you run it with windows PowerShel.

To fix, the final script should be like: (look at the colon instead of space after username switch)

MyTopShelfService.exe" install  -username:"MyUserName" -password:"***"